### PR TITLE
Restrict keymap scope to .editor:not(.mini)

### DIFF
--- a/keymaps/atomic-emacs.cson
+++ b/keymaps/atomic-emacs.cson
@@ -10,7 +10,7 @@
   'ctrl-x 1': 'pane:close-other-items'
   'ctrl-x o': 'window:focus-next-pane'
 
-'.editor':
+'.editor:not(.mini)':
   'ctrl-f': 'atomic-emacs:forward-char'
   'ctrl-b': 'atomic-emacs:backward-char'
   'ctrl-n': 'atomic-emacs:next-line'


### PR DESCRIPTION
Solves avendael/atomic-emacs#17 partially. Should continue to check for other instances where editor is undefined or null.
