### PR TITLE
Fixed issue with keybindings

### DIFF
--- a/keymaps/atomic-emacs.cson
+++ b/keymaps/atomic-emacs.cson
@@ -9,6 +9,10 @@
   'ctrl-x 0': 'pane:close'
   'ctrl-x 1': 'pane:close-other-items'
   'ctrl-x o': 'window:focus-next-pane'
+  'ctrl-b': 'unset!'
+  'ctrl-f': 'unset!'
+  'ctrl-p': 'unset!'
+  'ctrl-n': 'unset!'
 
 '.editor:not(.mini)':
   'ctrl-f': 'atomic-emacs:forward-char'


### PR DESCRIPTION
On mac os x (and possibly other platforms) the default key binding (on body) for ctrl-b (eg movement) gets triggered even though it's set in .editor:not(.mini) causing the editor to move several rows/positions instead of just one. This is the same for all the movement keys. 

This fixes that issue by unbinding these default keybindings.
