### PR TITLE
fix ctrl-k command. cut to end of line.

### DIFF
--- a/keymaps/atomic-emacs.cson
+++ b/keymaps/atomic-emacs.cson
@@ -16,7 +16,7 @@
   'ctrl-n': 'atomic-emacs:next-line'
   'ctrl-p': 'atomic-emacs:previous-line'
   'ctrl-l': 'atomic-emacs:recenter-top-bottom'
-  'ctrl-k': 'editor:delete-to-end-of-line'
+  'ctrl-k': 'editor:cut-to-end-of-line'
   'ctrl-g': 'core:cancel'
   'ctrl-y': 'core:paste'
   'ctrl-w': 'core:cut'


### PR DESCRIPTION
Refs #32.
Use cut-to-end-of-line to kill line with ctrl-k command.
