### PR TITLE
Option to use native implementation of c-f, c-b etc

### DIFF
--- a/lib/atomic-emacs.coffee
+++ b/lib/atomic-emacs.coffee
@@ -131,10 +131,16 @@ class AtomicEmacs
     deactivateCursors(@editor)
 
   forwardChar: (event) ->
+    if atom.config.get('atomic-emacs.useNativeNavigationKeys')
+      event.abortKeyBinding()
+      return
     @editor.moveCursors (cursor) ->
       cursor.moveRight()
 
   backwardChar: (event) ->
+    if atom.config.get('atomic-emacs.useNativeNavigationKeys')
+      event.abortKeyBinding()
+      return
     @editor.moveCursors (cursor) ->
       cursor.moveLeft()
 
@@ -151,10 +157,16 @@ class AtomicEmacs
       tools.skipWordCharactersBackward()
 
   nextLine: (event) ->
+    if atom.config.get('atomic-emacs.useNativeNavigationKeys')
+      event.abortKeyBinding()
+      return
     @editor.moveCursors (cursor) ->
       cursor.moveDown()
 
   previousLine: (event) ->
+    if atom.config.get('atomic-emacs.useNativeNavigationKeys')
+      event.abortKeyBinding()
+      return
     @editor.moveCursors (cursor) ->
       cursor.moveUp()
 

--- a/lib/atomic-emacs.coffee
+++ b/lib/atomic-emacs.coffee
@@ -138,11 +138,15 @@ class AtomicEmacs
       cursor.moveRight()
 
   backwardChar: (event) ->
-    if atom.config.get('atomic-emacs.useNativeNavigationKeys')
-      event.abortKeyBinding()
-      return
     @editor.moveCursors (cursor) ->
-      cursor.moveLeft()
+      mark = Mark.for(cursor)
+      if mark?.isActive()
+        cursor.selection.selectLeft()
+        return
+      if atom.config.get('atomic-emacs.useNativeNavigationKeys')
+        event.abortKeyBinding()
+      else
+        cursor.moveLeft()
 
   forwardWord: (event) ->
     @editor.moveCursors (cursor) ->

--- a/spec/atomic-emacs-spec.coffee
+++ b/spec/atomic-emacs-spec.coffee
@@ -263,6 +263,15 @@ describe "AtomicEmacs", ->
       @atomicEmacs.backwardChar(@event)
       expect(EditorState.get(@editor)).toEqual("[0]ab(0)c")
 
+    it "aborts key binding if flag is set", ->
+      atom.config.set('atomic-emacs.useNativeNavigationKeys', true)
+      EditorState.set(@editor, "x[0]")
+      event = jasmine.createSpyObj 'event', ['abortKeyBinding']
+      @atomicEmacs.backwardChar(event)
+
+      expect(event.abortKeyBinding).toHaveBeenCalled()
+      expect(EditorState.get(@editor)).toEqual("x[0]")
+
   describe "atomic-emacs:forward-char", ->
     it "moves the cursor forward one character", ->
       EditorState.set(@editor, "[0]x")
@@ -281,6 +290,15 @@ describe "AtomicEmacs", ->
       expect(EditorState.get(@editor)).toEqual("a(0)b[0]c")
       @atomicEmacs.forwardChar(@event)
       expect(EditorState.get(@editor)).toEqual("a(0)bc[0]")
+
+    it "aborts key binding if flag is set", ->
+      atom.config.set('atomic-emacs.useNativeNavigationKeys', true)
+      EditorState.set(@editor, "x[0]")
+      event = jasmine.createSpyObj 'event', ['abortKeyBinding']
+      @atomicEmacs.forwardChar(event)
+
+      expect(event.abortKeyBinding).toHaveBeenCalled()
+      expect(EditorState.get(@editor)).toEqual("x[0]")
 
   describe "atomic-emacs:backward-word", ->
     it "moves all cursors to the beginning of the current word if in a word", ->
@@ -353,6 +371,15 @@ describe "AtomicEmacs", ->
       @atomicEmacs.previousLine(@event)
       expect(EditorState.get(@editor)).toEqual("a[0]b\nab\na(0)b\n")
 
+    it "aborts key binding if flag is set", ->
+      atom.config.set('atomic-emacs.useNativeNavigationKeys', true)
+      EditorState.set(@editor, "x[0]")
+      event = jasmine.createSpyObj 'event', ['abortKeyBinding']
+      @atomicEmacs.previousLine(event)
+
+      expect(event.abortKeyBinding).toHaveBeenCalled()
+      expect(EditorState.get(@editor)).toEqual("x[0]")
+
   describe "atomic-emacs:next-line", ->
     it "moves the cursor down one line", ->
       EditorState.set(@editor, "a[0]b\nab\n")
@@ -371,6 +398,15 @@ describe "AtomicEmacs", ->
       expect(EditorState.get(@editor)).toEqual("a(0)b\na[0]b\nab\n")
       @atomicEmacs.nextLine(@event)
       expect(EditorState.get(@editor)).toEqual("a(0)b\nab\na[0]b\n")
+
+    it "aborts key binding if flag is set", ->
+      atom.config.set('atomic-emacs.useNativeNavigationKeys', true)
+      EditorState.set(@editor, "a[0]b\nab\nab\n")
+      event = jasmine.createSpyObj 'event', ['abortKeyBinding']
+      @atomicEmacs.nextLine(event)
+
+      expect(event.abortKeyBinding).toHaveBeenCalled()
+      expect(EditorState.get(@editor)).toEqual("a[0]b\nab\nab\n")
 
   describe "atomic-emacs:backward-paragraph", ->
     it "moves the cursor backwards to an empty line", ->


### PR DESCRIPTION
Adds an option:
![alt text](https://api.monosnap.com/image/download?id=Gc2pheHoXYsb1r5TxDWO4sXQOhqKjr "Screen1")
Alternatively you can set it in your `config.cson`:
```
"atomic-emacs":
    useNativeNavigationKeys: true
```
