### PR TITLE
Add ctrl-a/ctrl-e keybindings for linux

### DIFF
--- a/keymaps/atomic-emacs.cson
+++ b/keymaps/atomic-emacs.cson
@@ -59,6 +59,10 @@
   'left': 'atomic-emacs:backward-char'
   'right': 'atomic-emacs:forward-char'
 
+'.platform-linux .editor':
+  'ctrl-a': 'editor:move-to-first-character-of-line'
+  'ctrl-e': 'editor:move-to-end-of-screen-line'
+
 '.find-and-replace':
   'ctrl-s': 'find-and-replace:find-next'
   'ctrl-r': 'find-and-replace:find-previous'


### PR DESCRIPTION
It sounds like on OS-X the ctrl-a/ctrl-e keybindings come for free, but they need to be manually added for linux.  These are the same keymappings as for home/end on linux, so it's possible these are not perfect, but they're certainly better than ctrl-a being select all!

Note that for a line with the contents "   foo" move-to-first-character-of-line first jumps to the "f" and then when subsequently pressed it jumps to the leftmost character and continues alternating between the two when repeatedly pressed.  This is the opposite sequence from my emacs23 config, but it seems like the superior choice.  (Although it might be infuriating from a muscle memory perspective for people not trying to transition entirely!)