### PR TITLE
Do not override keymappings when autocomplete is active

### DIFF
--- a/keymaps/atomic-emacs.cson
+++ b/keymaps/atomic-emacs.cson
@@ -10,7 +10,7 @@
   'ctrl-x 1': 'pane:close-other-items'
   'ctrl-x o': 'window:focus-next-pane'
 
-'.editor:not(.mini)':
+'.editor:not(.mini):not(.autocomplete-active)':
   'ctrl-f': 'atomic-emacs:forward-char'
   'ctrl-b': 'atomic-emacs:backward-char'
   'ctrl-n': 'atomic-emacs:next-line'


### PR DESCRIPTION
Fixes https://github.com/avendael/atomic-emacs/issues/49