### PR TITLE
Fix behavior of ctrl-a and alt-m.

### DIFF
--- a/keymaps/atomic-emacs.cson
+++ b/keymaps/atomic-emacs.cson
@@ -11,6 +11,7 @@
   'ctrl-x o': 'window:focus-next-pane'
 
 'atom-text-editor:not([mini])':
+  'ctrl-a': 'editor:move-to-beginning-of-line'
   'ctrl-f': 'atomic-emacs:forward-char'
   'ctrl-b': 'atomic-emacs:backward-char'
   'ctrl-n': 'atomic-emacs:next-line'
@@ -45,7 +46,7 @@
   'alt-v': 'atomic-emacs:scroll-down'
   'alt-<': 'core:move-to-top'
   'alt->': 'core:move-to-bottom'
-  'alt-m': 'editor:move-to-first-character-of-line'
+  'alt-m': 'atomic-emacs:back-to-indentation'
   'alt-/': 'autocomplete:toggle'
   'alt-.': 'symbols-view:toggle-file-symbols'
   'alt-^': 'atomic-emacs:delete-indentation'
@@ -61,7 +62,6 @@
   'right': 'atomic-emacs:forward-char'
 
 '.platform-linux atom-text-editor':
-  'ctrl-a': 'editor:move-to-first-character-of-line'
   'ctrl-e': 'editor:move-to-end-of-screen-line'
 
 '.find-and-replace':

--- a/lib/atomic-emacs.coffee
+++ b/lib/atomic-emacs.coffee
@@ -129,6 +129,17 @@ class AtomicEmacs
       tools.skipNonWordCharactersBackward()
       tools.skipWordCharactersBackward()
 
+  backToIndentation: (event) ->
+    editor = @editor()
+    editor.moveCursors (cursor) ->
+      position = cursor.getBufferPosition()
+      line = editor.lineTextForBufferRow(position.row)
+      targetColumn = line.search(/\S/)
+      targetColumn = line.length if targetColumn == -1
+
+      if position.column != targetColumn
+        cursor.setBufferPosition([position.row, targetColumn])
+
   nextLine: (event) ->
     if atom.config.get('atomic-emacs.useNativeNavigationKeys')
       event.abortKeyBinding()
@@ -279,6 +290,7 @@ module.exports =
       "atomic-emacs:just-one-space": (event) -> atomicEmacs.justOneSpace(event)
       "atomic-emacs:kill-word": (event) -> atomicEmacs.killWord(event)
       "atomic-emacs:mark-whole-buffer": (event) -> atomicEmacs.markWholeBuffer(event)
+      "atomic-emacs:back-to-indentation": (event) -> atomicEmacs.backToIndentation(event)
       "atomic-emacs:next-line": (event) -> atomicEmacs.nextLine(event)
       "atomic-emacs:open-line": (event) -> atomicEmacs.openLine(event)
       "atomic-emacs:previous-line": (event) -> atomicEmacs.previousLine(event)

--- a/spec/atomic-emacs-spec.coffee
+++ b/spec/atomic-emacs-spec.coffee
@@ -349,6 +349,32 @@ describe "AtomicEmacs", ->
       @atomicEmacs.forwardWord(@event)
       expect(EditorState.get(@editor)).toEqual("aa bb  [0]")
 
+  describe "atomic-emacs:back-to-indentation", ->
+    it "moves cursors forward to the first character if in leading space", ->
+      EditorState.set(@editor, "[0]  aa\n [1] bb\n")
+      @atomicEmacs.backToIndentation(@event)
+      expect(EditorState.get(@editor)).toEqual("  [0]aa\n  [1]bb\n")
+
+    it "moves cursors back to the first character if past it", ->
+      EditorState.set(@editor, "  a[0]a\n  bb[1]\n")
+      @atomicEmacs.backToIndentation(@event)
+      expect(EditorState.get(@editor)).toEqual("  [0]aa\n  [1]bb\n")
+
+    it "leaves cursors alone if already there", ->
+      EditorState.set(@editor, "  [0]aa\n[1]  bb\n")
+      @atomicEmacs.backToIndentation(@event)
+      expect(EditorState.get(@editor)).toEqual("  [0]aa\n  [1]bb\n")
+
+    it "moves cursors to the end of their lines if they only contain spaces", ->
+      EditorState.set(@editor, " [0] \n  [1]\n")
+      @atomicEmacs.backToIndentation(@event)
+      expect(EditorState.get(@editor)).toEqual("  [0]\n  [1]\n")
+
+    it "merges cursors after moving", ->
+      EditorState.set(@editor, "  a[0]a[1]\n")
+      @atomicEmacs.backToIndentation(@event)
+      expect(EditorState.get(@editor)).toEqual("  [0]aa\n")
+
   describe "atomic-emacs:previous-line", ->
     it "moves the cursor up one line", ->
       EditorState.set(@editor, "ab\na[0]b\n")


### PR DESCRIPTION
Atom's editor:move-to-first-character-of-line toggles between start of
line and first character of line if you're already there. This binds
ctrl-a to editor:move-to-beginning-of-line, and makes alt-m behave more
like Emacs, which does not toggle, and just moves straight to the first
nonspace character (or end of line if there's only whitespace).