### PR TITLE
Write kills to clipboard on copy-region-as-kill

### DIFF
--- a/lib/emacs-editor.coffee
+++ b/lib/emacs-editor.coffee
@@ -137,12 +137,15 @@ class EmacsEditor
     State.killed()
 
   copyRegionAsKill: ->
+    kills = []
     method = if State.killing then 'append' else 'push'
     @editor.transact =>
       for selection in @editor.getSelections()
         emacsCursor = EmacsCursor.for(selection.cursor)
         emacsCursor.killRing()[method](selection.getText())
+        kills.push emacsCursor.killRing().getCurrentEntry()
         emacsCursor.mark().deactivate()
+    atom.clipboard.write(kills.join("\n"))
 
   yank: ->
     @editor.transact =>

--- a/spec/atomic-emacs-spec.coffee
+++ b/spec/atomic-emacs-spec.coffee
@@ -599,6 +599,10 @@ describe "AtomicEmacs", ->
         atom.commands.dispatch @editorView, 'atomic-emacs:copy-region-as-kill'
         expect(KillRing.global.getEntries()).toEqual(['b'])
 
+      it "puts the kill on the clipboard", ->
+        atom.commands.dispatch @editorView, 'atomic-emacs:copy-region-as-kill'
+        expect(atom.clipboard.read()).toEqual('b')
+
     describe "when there are multiple cursors", ->
       beforeEach ->
         @testEditor.setState("a(0)b[0]c d[1]e(1)f")
@@ -608,6 +612,11 @@ describe "AtomicEmacs", ->
         expect(@getKillRing(0).getEntries()).toEqual(['b'])
         expect(@getKillRing(1).getEntries()).toEqual(['e'])
         expect(KillRing.global.getEntries()).toEqual([])
+
+      it "puts the kills on the clipboard separated by newlines", ->
+        @testEditor.setState("a(0)b[0]c d(1)e[1]f")
+        atom.commands.dispatch @editorView, 'atomic-emacs:copy-region-as-kill'
+        expect(atom.clipboard.read()).toEqual("b\ne")
 
     it "appends to the last kill ring entry if killing", ->
       @testEditor.setState("a[0]b(0)")


### PR DESCRIPTION
`copy-region-as-kill` writes kills to clipboard like other kill-ring functions.
Refs #95.