### PR TITLE
Change the key-binding of ctrl-a from editor:move-to-beginning-of-lin…

### DIFF
--- a/keymaps/atomic-emacs.cson
+++ b/keymaps/atomic-emacs.cson
@@ -42,7 +42,7 @@
   'alt-{': 'atomic-emacs:backward-paragraph'
   'alt-}': 'atomic-emacs:forward-paragraph'
   'alt-m': 'atomic-emacs:back-to-indentation'
-  'ctrl-a': 'editor:move-to-beginning-of-line'
+  'ctrl-a': 'editor:move-to-first-character-of-line'
   'ctrl-s': 'find-and-replace:show'
   'ctrl-r': 'find-and-replace:show'
   'alt-<': 'core:move-to-top'


### PR DESCRIPTION
…e to editor:move-to-first-character-of-line

Trying to mimic the behavior of 'Home' key in Atom, and also make it more
convenient for the programmer to move to the beginning of the content in a
line, at least in my own experience :)