### PR TITLE
Full system clipboard integration

### DIFF
--- a/lib/atomic-emacs.coffee
+++ b/lib/atomic-emacs.coffee
@@ -42,6 +42,10 @@ module.exports =
       type: 'boolean',
       default: false,
       title: 'Use kill ring for built-in copy & cut commands.'
+    killToClipboard:
+      type: 'boolean',
+      default: true,
+      title: 'Send kills to the system clipboard'
     killWholeLine:
       type: 'boolean',
       default: false,

--- a/lib/atomic-emacs.coffee
+++ b/lib/atomic-emacs.coffee
@@ -46,6 +46,10 @@ module.exports =
       type: 'boolean',
       default: true,
       title: 'Send kills to the system clipboard'
+    yankFromClipboard:
+      type: 'boolean',
+      default: false,
+      title: 'Yank changed text from the system clipboard'
     killWholeLine:
       type: 'boolean',
       default: false,

--- a/lib/emacs-cursor.coffee
+++ b/lib/emacs-cursor.coffee
@@ -399,7 +399,7 @@ class EmacsCursor
             hit.stop()
       result or point
     else
-      @_locateForwardFrom(point, /\W/i)?.start or eob
+      @_locateForwardFrom(point, /[\W\n]/i)?.start or eob
 
   _sexpBackwardFrom: (point) ->
     point = @_locateBackwardFrom(point, /[\w()[\]{}'"]/i)?.end or BOB
@@ -426,7 +426,7 @@ class EmacsCursor
             hit.stop()
       result or point
     else
-      @_locateBackwardFrom(point, /\W/i)?.end or BOB
+      @_locateBackwardFrom(point, /[\W\n]/i)?.end or BOB
 
   _locateBackwardFrom: (point, regExp) ->
     result = null

--- a/lib/emacs-editor.coffee
+++ b/lib/emacs-editor.coffee
@@ -114,7 +114,7 @@ class EmacsEditor
     @editor.transact =>
       @moveEmacsCursors (emacsCursor, cursor) =>
         kills.push emacsCursor.backwardKillWord(method)
-    atom.clipboard.write(kills.join("\n"))
+    @_updateGlobalKillRing(kills)
     State.killed()
 
   killWord: ->
@@ -123,7 +123,7 @@ class EmacsEditor
     @editor.transact =>
       @moveEmacsCursors (emacsCursor) =>
         kills.push emacsCursor.killWord(method)
-    atom.clipboard.write(kills.join("\n"))
+    @_updateGlobalKillRing(kills, method)
     State.killed()
 
   killLine: ->
@@ -132,7 +132,7 @@ class EmacsEditor
     @editor.transact =>
       @moveEmacsCursors (emacsCursor) =>
         kills.push emacsCursor.killLine(method)
-    atom.clipboard.write(kills.join("\n"))
+    @_updateGlobalKillRing(kills, method)
     State.killed()
 
   killRegion: ->
@@ -141,7 +141,7 @@ class EmacsEditor
     @editor.transact =>
       @moveEmacsCursors (emacsCursor) =>
         kills.push emacsCursor.killRegion(method)
-    atom.clipboard.write(kills.join("\n"))
+    @_updateGlobalKillRing(kills, method)
     State.killed()
 
   copyRegionAsKill: ->
@@ -153,7 +153,7 @@ class EmacsEditor
         emacsCursor.killRing()[method](selection.getText())
         kills.push emacsCursor.killRing().getCurrentEntry()
         emacsCursor.mark().deactivate()
-    atom.clipboard.write(kills.join("\n"))
+    @_updateGlobalKillRing(kills, method)
 
   yank: ->
     @editor.transact =>
@@ -174,6 +174,13 @@ class EmacsEditor
       for emacsCursor in @getEmacsCursors()
         emacsCursor.rotateYank(1)
     State.yanked()
+
+  _updateGlobalKillRing: (kills, method) ->
+    if @editor.hasMultipleCursors()
+      if method == "push"
+        KillRing.global.push(kills.join("\n"))
+      else
+        KillRing.global.replace(kills.join("\n"))
 
   ###
   Section: Editing

--- a/lib/kill-ring.coffee
+++ b/lib/kill-ring.coffee
@@ -4,11 +4,15 @@ class KillRing
     @currentIndex = -1
     @entries = []
     @limit = 500
+    @lastSystemClip = ''
+    @global = true
 
   fork: ->
     fork = new KillRing
     fork.setEntries(@entries)
     fork.currentIndex = @currentIndex
+    fork.lastSystemClip = @lastSystemClip
+    fork.global = false
     fork
 
   isEmpty: ->
@@ -25,13 +29,19 @@ class KillRing
     @currentIndex = @entries.length - 1
     this
 
+  _pushSystemClipboard: (text) ->
+    if global
+      atom.clipboard.write(text)
+
   push: (text) ->
+    @_pushSystemClipboard(text)
     @entries.push(text)
     if @entries.length > @limit
       @entries.shift()
     @currentIndex = @entries.length - 1
 
   append: (text) ->
+    @_pushSystemClipboard(text)
     if @entries.length == 0
       @push(text)
     else
@@ -40,11 +50,21 @@ class KillRing
       @currentIndex = @entries.length - 1
 
   prepend: (text) ->
+    @_pushSystemClipboard(text)
     if @entries.length == 0
       @push(text)
     else
       index = @entries.length - 1
       @entries[index] = "#{text}#{@entries[index]}"
+      @currentIndex = @entries.length - 1
+
+  replace: (text) ->
+    @_pushSystemClipboard(text)
+    if @entries.length == 0
+      @push(text)
+    else
+      index = @entries.length - 1
+      @entries[index] = text
       @currentIndex = @entries.length - 1
 
   getCurrentEntry: ->

--- a/lib/kill-ring.coffee
+++ b/lib/kill-ring.coffee
@@ -30,7 +30,7 @@ class KillRing
     this
 
   _pushSystemClipboard: (text) ->
-    if global
+    if global and atom.config.get("atomic-emacs.killToClipboard")
       atom.clipboard.write(text)
 
   push: (text) ->

--- a/spec/atomic-emacs-spec.coffee
+++ b/spec/atomic-emacs-spec.coffee
@@ -10,6 +10,7 @@ describe "AtomicEmacs", ->
   beforeEach ->
     waitsForPromise =>
       atom.workspace.open().then (@editor) =>
+        atom.config.set 'atomic-emacs.killToClipboard', true
         @emacsEditor = new EmacsEditor(@editor)
         @testEditor = new TestEditor(@editor)
         @editorView = atom.views.getView(@editor)
@@ -334,6 +335,14 @@ describe "AtomicEmacs", ->
         atom.commands.dispatch @editorView, 'atomic-emacs:backward-kill-word'
         expect(atom.clipboard.read()).toEqual('b')
 
+      describe "When atomic-emacs.killToClipboard is off", ->
+        beforeEach ->
+          atom.config.set 'atomic-emacs.killToClipboard', false
+
+        it "doesn't put the kill on the clipboard", ->
+          atom.commands.dispatch @editorView, 'atomic-emacs:backward-kill-word'
+          expect(atom.clipboard.read()).toEqual('initial clipboard content')
+
     describe "when there are multiple cursors", ->
       it "kills to a cursor-local kill ring", ->
         @testEditor.setState("a(0)b[0]c d(1)e[1]f")
@@ -346,6 +355,15 @@ describe "AtomicEmacs", ->
         @testEditor.setState("a(0)b[0]c d(1)e[1]f")
         atom.commands.dispatch @editorView, 'atomic-emacs:backward-kill-word'
         expect(atom.clipboard.read()).toEqual("b\ne")
+
+      describe "When atomic-emacs.killToClipboard is off", ->
+        beforeEach ->
+          atom.config.set 'atomic-emacs.killToClipboard', false
+
+        it "doesn't put the kill clipboard separated by newlines", ->
+          @testEditor.setState("a(0)b[0]c d(1)e[1]f")
+          atom.commands.dispatch @editorView, 'atomic-emacs:backward-kill-word'
+          expect(atom.clipboard.read()).toEqual('initial clipboard content')
 
       it "merges cursors", ->
         @testEditor.setState("a[1]b[0]c")
@@ -422,6 +440,14 @@ describe "AtomicEmacs", ->
         atom.commands.dispatch @editorView, 'atomic-emacs:kill-word'
         expect(atom.clipboard.read()).toEqual('b')
 
+      describe "When atomic-emacs.killToClipboard is off", ->
+        beforeEach ->
+          atom.config.set 'atomic-emacs.killToClipboard', false
+
+        it "doesn't put the kill on the clipboard", ->
+          atom.commands.dispatch @editorView, 'atomic-emacs:kill-word'
+          expect(atom.clipboard.read()).toEqual('initial clipboard content')
+
     describe "when there are multiple cursors", ->
       it "kills to a cursor-local kill ring", ->
         @testEditor.setState("a[0]b(0)c d[1]e(1)f")
@@ -434,6 +460,15 @@ describe "AtomicEmacs", ->
         @testEditor.setState("a(0)b[0]c d(1)e[1]f")
         atom.commands.dispatch @editorView, 'atomic-emacs:kill-word'
         expect(atom.clipboard.read()).toEqual("b\ne")
+
+      describe "When atomic-emacs.killToClipboard is off", ->
+        beforeEach ->
+          atom.config.set 'atomic-emacs.killToClipboard', false
+
+        it "doesn't put the kill on the clipboard separated by newlines", ->
+          @testEditor.setState("a(0)b[0]c d(1)e[1]f")
+          atom.commands.dispatch @editorView, 'atomic-emacs:kill-word'
+          expect(atom.clipboard.read()).toEqual('initial clipboard content')
 
       it "merges cursors", ->
         @testEditor.setState("a[0]b[1]c")
@@ -547,6 +582,14 @@ describe "AtomicEmacs", ->
         atom.commands.dispatch @editorView, 'atomic-emacs:kill-line'
         expect(atom.clipboard.read()).toEqual('bc')
 
+      describe "When atomic-emacs.killToClipboard is off", ->
+        beforeEach ->
+          atom.config.set 'atomic-emacs.killToClipboard', false
+
+        it "doesn't put the kill on the clipboard", ->
+          atom.commands.dispatch @editorView, 'atomic-emacs:kill-word'
+          expect(atom.clipboard.read()).toEqual('initial clipboard content')
+
     describe "when there are multiple cursors", ->
       beforeEach ->
         @testEditor.setState("a[0]bc\n d[1]ef")
@@ -561,6 +604,15 @@ describe "AtomicEmacs", ->
         @testEditor.setState("a(0)b[0]c d(1)e[1]f")
         atom.commands.dispatch @editorView, 'atomic-emacs:kill-line'
         expect(atom.clipboard.read()).toEqual("b\ne")
+
+      describe "When atomic-emacs.killToClipboard is off", ->
+        beforeEach ->
+          atom.config.set 'atomic-emacs.killToClipboard', false
+
+        it "doesn't put the kill on the clipboard separated by newlines", ->
+          @testEditor.setState("a(0)b[0]c d(1)e[1]f")
+          atom.commands.dispatch @editorView, 'atomic-emacs:kill-line'
+          expect(atom.clipboard.read()).toEqual('initial clipboard content')
 
       it "merges cursors", ->
         @testEditor.setState("a[0]b\n[1]c")
@@ -604,6 +656,14 @@ describe "AtomicEmacs", ->
         atom.commands.dispatch @editorView, 'atomic-emacs:kill-region'
         expect(atom.clipboard.read()).toEqual('b')
 
+      describe "When atomic-emacs.killToClipboard is off", ->
+        beforeEach ->
+          atom.config.set 'atomic-emacs.killToClipboard', false
+
+        it "doesn't put the kill on the clipboard", ->
+          atom.commands.dispatch @editorView, 'atomic-emacs:kill-region'
+          expect(atom.clipboard.read()).toEqual('initial clipboard content')
+
     describe "when there are multiple cursors", ->
       beforeEach ->
         @testEditor.setState("a(0)b[0]c d[1]e(1)f")
@@ -618,6 +678,15 @@ describe "AtomicEmacs", ->
         @testEditor.setState("a(0)b[0]c d(1)e[1]f")
         atom.commands.dispatch @editorView, 'atomic-emacs:kill-region'
         expect(atom.clipboard.read()).toEqual("b\ne")
+
+      describe "When atomic-emacs.killToClipboard is off", ->
+        beforeEach ->
+          atom.config.set 'atomic-emacs.killToClipboard', false
+
+        it "doesn't put the kill on the clipboard separated by newlines", ->
+          @testEditor.setState("a(0)b[0]c d(1)e[1]f")
+          atom.commands.dispatch @editorView, 'atomic-emacs:kill-region'
+          expect(atom.clipboard.read()).toEqual('initial clipboard content')
 
       it "merges cursors", ->
         @testEditor.setState("a(0)a[0](1)b[1]b")
@@ -679,6 +748,14 @@ describe "AtomicEmacs", ->
         atom.commands.dispatch @editorView, 'atomic-emacs:copy-region-as-kill'
         expect(atom.clipboard.read()).toEqual('b')
 
+      describe "When atomic-emacs.killToClipboard is off", ->
+        beforeEach ->
+          atom.config.set 'atomic-emacs.killToClipboard', false
+
+        it "doesn't put the kill on the clipboard", ->
+          atom.commands.dispatch @editorView, 'atomic-emacs:copy-region-as-kill'
+          expect(atom.clipboard.read()).toEqual('initial clipboard content')
+
     describe "when there are multiple cursors", ->
       beforeEach ->
         @testEditor.setState("a(0)b[0]c d[1]e(1)f")
@@ -693,6 +770,15 @@ describe "AtomicEmacs", ->
         @testEditor.setState("a(0)b[0]c d(1)e[1]f")
         atom.commands.dispatch @editorView, 'atomic-emacs:copy-region-as-kill'
         expect(atom.clipboard.read()).toEqual("b\ne")
+
+      describe "When atomic-emacs.killToClipboard is off", ->
+        beforeEach ->
+          atom.config.set 'atomic-emacs.killToClipboard', false
+
+        it "doesn't put the kill on the clipboard separated by newlines", ->
+          @testEditor.setState("a(0)b[0]c d(1)e[1]f")
+          atom.commands.dispatch @editorView, 'atomic-emacs:copy-region-as-kill'
+          expect(atom.clipboard.read()).toEqual('initial clipboard content')
 
     it "appends to the last kill ring entry if killing", ->
       @testEditor.setState("a[0]b(0)")

--- a/spec/atomic-emacs-spec.coffee
+++ b/spec/atomic-emacs-spec.coffee
@@ -122,9 +122,9 @@ describe "AtomicEmacs", ->
 
   describe "atomic-emacs:backward-sexp", ->
     it "moves all cursors backward one symbolic expression", ->
-      @testEditor.setState("aa [0]\n(bb cc)[1]\n")
+      @testEditor.setState("(aa bb)\naa [0]\n(bb cc)[1]\n")
       atom.commands.dispatch @editorView, 'atomic-emacs:backward-sexp'
-      expect(@testEditor.getState()).toEqual("[0]aa \n[1](bb cc)\n")
+      expect(@testEditor.getState()).toEqual("(aa bb)\n[0]aa \n[1](bb cc)\n")
 
     it "merges cursors that coincide", ->
       @testEditor.setState("aa[0] [1]")
@@ -133,9 +133,9 @@ describe "AtomicEmacs", ->
 
   describe "atomic-emacs:forward-sexp", ->
     it "moves all cursors forward one symbolic expression", ->
-      @testEditor.setState("[0]  aa\n[1](bb cc)\n")
+      @testEditor.setState("[0]aa\n[1](bb cc)\n")
       atom.commands.dispatch @editorView, 'atomic-emacs:forward-sexp'
-      expect(@testEditor.getState()).toEqual("  aa[0]\n(bb cc)[1]\n")
+      expect(@testEditor.getState()).toEqual("aa[0]\n(bb cc)[1]\n")
 
     it "merges cursors that coincide", ->
       @testEditor.setState("[0] [1]aa")

--- a/spec/atomic-emacs-spec.coffee
+++ b/spec/atomic-emacs-spec.coffee
@@ -340,7 +340,7 @@ describe "AtomicEmacs", ->
         atom.commands.dispatch @editorView, 'atomic-emacs:backward-kill-word'
         expect(@getKillRing(0).getEntries()).toEqual(['b'])
         expect(@getKillRing(1).getEntries()).toEqual(['e'])
-        expect(KillRing.global.getEntries()).toEqual([])
+        expect(KillRing.global.getEntries()).toEqual(['b\ne'])
 
       it "puts the kills on the clipboard separated by newlines", ->
         @testEditor.setState("a(0)b[0]c d(1)e[1]f")
@@ -428,7 +428,7 @@ describe "AtomicEmacs", ->
         atom.commands.dispatch @editorView, 'atomic-emacs:kill-word'
         expect(@getKillRing(0).getEntries()).toEqual(['b'])
         expect(@getKillRing(1).getEntries()).toEqual(['e'])
-        expect(KillRing.global.getEntries()).toEqual([])
+        expect(KillRing.global.getEntries()).toEqual(['b\ne'])
 
       it "puts the kills on the clipboard separated by newlines", ->
         @testEditor.setState("a(0)b[0]c d(1)e[1]f")
@@ -555,7 +555,7 @@ describe "AtomicEmacs", ->
         atom.commands.dispatch @editorView, 'atomic-emacs:kill-line'
         expect(@getKillRing(0).getEntries()).toEqual(['bc'])
         expect(@getKillRing(1).getEntries()).toEqual(['ef'])
-        expect(KillRing.global.getEntries()).toEqual([])
+        expect(KillRing.global.getEntries()).toEqual(['bc\nef'])
 
       it "puts the kills on the clipboard separated by newlines", ->
         @testEditor.setState("a(0)b[0]c d(1)e[1]f")
@@ -612,7 +612,7 @@ describe "AtomicEmacs", ->
         atom.commands.dispatch @editorView, 'atomic-emacs:kill-region'
         expect(@getKillRing(0).getEntries()).toEqual(['b'])
         expect(@getKillRing(1).getEntries()).toEqual(['e'])
-        expect(KillRing.global.getEntries()).toEqual([])
+        expect(KillRing.global.getEntries()).toEqual(['b\ne'])
 
       it "puts the kills on the clipboard separated by newlines", ->
         @testEditor.setState("a(0)b[0]c d(1)e[1]f")
@@ -687,7 +687,7 @@ describe "AtomicEmacs", ->
         atom.commands.dispatch @editorView, 'atomic-emacs:copy-region-as-kill'
         expect(@getKillRing(0).getEntries()).toEqual(['b'])
         expect(@getKillRing(1).getEntries()).toEqual(['e'])
-        expect(KillRing.global.getEntries()).toEqual([])
+        expect(KillRing.global.getEntries()).toEqual(['b\ne'])
 
       it "puts the kills on the clipboard separated by newlines", ->
         @testEditor.setState("a(0)b[0]c d(1)e[1]f")

--- a/spec/kill-ring-spec.coffee
+++ b/spec/kill-ring-spec.coffee
@@ -57,3 +57,77 @@ describe "KillRing", ->
       @killRing.push('b')
       @killRing.prepend('c')
       expect(@killRing.getEntries()).toEqual(['a', 'cb'])
+
+  describe "rotate", ->
+    it "rotates the killRing contents", ->
+      @killRing.push('a')
+      @killRing.push('b')
+      @killRing.push('c')
+      expect(@killRing.getCurrentEntry()).toEqual('c')
+      expect(@killRing.rotate(-1)).toEqual('b')
+      expect(@killRing.getCurrentEntry()).toEqual('b')
+      expect(@killRing.rotate(-1)).toEqual('a')
+      expect(@killRing.rotate(-1)).toEqual('c')
+      expect(@killRing.rotate(1)).toEqual('a')
+      @killRing.push('d')
+      expect(@killRing.getCurrentEntry()).toEqual('d')
+      expect(@killRing.rotate(-1)).toEqual('c')
+
+  describe "with atomic-emacs.yankFromClipboard and atomic-emacs.pushToClipboard enabled
+      it pulls from the clipboard before preforming any operations", ->
+    beforeEach ->
+      atom.config.set "atomic-emacs.yankFromClipboard", true
+      atom.config.set 'atomic-emacs.killToClipboard', true
+
+    describe "push", ->
+      it "appends the given entry to the list and sends it to the clipboard", ->
+        @killRing.push('a')
+        expect(atom.clipboard.read()).toEqual('a')
+        atom.clipboard.write('b')
+        @killRing.push('c')
+        expect(atom.clipboard.read()).toEqual('c')
+        expect(@killRing.getEntries()).toEqual(['initial clipboard content', 'a', 'b', 'c'])
+
+    describe "append", ->
+      it "", ->
+        @killRing.append('a')
+        expect(atom.clipboard.read()).toEqual('initial clipboard contenta')
+        expect(@killRing.getEntries()).toEqual(['initial clipboard contenta'])
+
+      it "appends the given text to the last entry otherwise", ->
+        @killRing.push('a')
+        atom.clipboard.write('b')
+        @killRing.append('c')
+        expect(atom.clipboard.read()).toEqual('bc')
+        expect(@killRing.getEntries()).toEqual(['initial clipboard content', 'a', 'bc'])
+
+    describe "prepend", ->
+      it "creates an entry if the kill ring is empty", ->
+        @killRing.prepend('a')
+        expect(atom.clipboard.read()).toEqual('ainitial clipboard content')
+        expect(@killRing.getEntries()).toEqual(['ainitial clipboard content'])
+
+      it "prepends the given text to the last entry otherwise", ->
+        @killRing.push('a')
+        atom.clipboard.write('b')
+        @killRing.prepend('c')
+        expect(atom.clipboard.read()).toEqual('cb')
+        expect(@killRing.getEntries()).toEqual(['initial clipboard content', 'a', 'cb'])
+
+    describe "rotate, getCurrentEntry, and position tracking", ->
+      it "rotates the currentEntry through the killRing contents", ->
+        expect(@killRing.getCurrentEntry()).toEqual('initial clipboard content')
+        @killRing.push('a')
+        @killRing.push('b')
+        @killRing.push('c')
+        expect(@killRing.getCurrentEntry()).toEqual('c')
+        expect(@killRing.rotate(-1)).toEqual('b')
+        expect(@killRing.getCurrentEntry()).toEqual('b')
+        expect(@killRing.rotate(-1)).toEqual('a')
+        expect(@killRing.rotate(-1)).toEqual('initial clipboard content')
+        atom.clipboard.write('d')
+        expect(@killRing.rotate(-1)).toEqual('c')
+        atom.clipboard.write('e')
+        expect(@killRing.getCurrentEntry()).toEqual('e')
+
+


### PR DESCRIPTION
Added new features relating to system clipboard integration.  When enabled, before killing or yanking, any changes to the system clipboard will be added to the kill ring.