### PR TITLE
Get editor model from event target parent

### DIFF
--- a/lib/atomic-emacs.coffee
+++ b/lib/atomic-emacs.coffee
@@ -20,7 +20,7 @@ afterCommand = (event) ->
 
 getEditor = (event) ->
   # Get editor from the event if possible so we can target mini-editors.
-  editor = event.target?.getModel?() ? atom.workspace.getActiveTextEditor()
+  editor = event.target?.closest('atom-text-editor')?.getModel?() ? atom.workspace.getActiveTextEditor()
   EmacsEditor.for(editor)
 
 closeOtherPanes = (event) ->


### PR DESCRIPTION
This is a possible fix for issue #133. It seems that perhaps in 1.19 something changed about the `event.target` property, since events from the command palette or find/replace bar just have a reference to a child `<input>` element of the `atom-text-editor`, which is the actual  element with a `getModel()` method that returns an editor.

I'm not sure this is the *right* fix, but it's working for me.