### PR TITLE
Add commands for 'backward-list' and 'forward-list'

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Emacs keybindings for Atom.
     'alt-right': 'atomic-emacs:forward-word'
     'ctrl-alt-b': 'atomic-emacs:backward-sexp'
     'ctrl-alt-f': 'atomic-emacs:forward-sexp'
+    'ctrl-alt-p': 'atomic-emacs:backward-list'
+    'ctrl-alt-n': 'atomic-emacs:forward-list'
     'alt-{': 'atomic-emacs:backward-paragraph'
     'alt-}': 'atomic-emacs:forward-paragraph'
     'alt-m': 'atomic-emacs:back-to-indentation'

--- a/keymaps/atomic-emacs.cson
+++ b/keymaps/atomic-emacs.cson
@@ -39,6 +39,8 @@
   'alt-right': 'atomic-emacs:forward-word'
   'ctrl-alt-b': 'atomic-emacs:backward-sexp'
   'ctrl-alt-f': 'atomic-emacs:forward-sexp'
+  'ctrl-alt-p': 'atomic-emacs:backward-list'
+  'ctrl-alt-n': 'atomic-emacs:forward-list'
   'alt-{': 'atomic-emacs:backward-paragraph'
   'alt-}': 'atomic-emacs:forward-paragraph'
   'alt-m': 'atomic-emacs:back-to-indentation'

--- a/lib/atomic-emacs.coffee
+++ b/lib/atomic-emacs.coffee
@@ -73,6 +73,8 @@ module.exports =
       "atomic-emacs:forward-word": (event) -> getEditor(event).forwardWord()
       "atomic-emacs:backward-sexp": (event) -> getEditor(event).backwardSexp()
       "atomic-emacs:forward-sexp": (event) -> getEditor(event).forwardSexp()
+      "atomic-emacs:backward-list": (event) -> getEditor(event).backwardList()
+      "atomic-emacs:forward-list": (event) -> getEditor(event).forwardList()
       "atomic-emacs:previous-line": (event) -> getEditor(event).previousLine()
       "atomic-emacs:next-line": (event) -> getEditor(event).nextLine()
       "atomic-emacs:backward-paragraph": (event) -> getEditor(event).backwardParagraph()

--- a/lib/emacs-cursor.coffee
+++ b/lib/emacs-cursor.coffee
@@ -278,6 +278,18 @@ class EmacsCursor
     target = @_sexpBackwardFrom(point)
     @cursor.setBufferPosition(target)
 
+  # Skip to the end of the current or next list.
+  skipListForward: ->
+    point = @cursor.getBufferPosition()
+    target = @_listForwardFrom(point)
+    @cursor.setBufferPosition(target)
+
+  # Skip to the beginning of the current or previous list.
+  skipListBackward: ->
+    point = @cursor.getBufferPosition()
+    target = @_listBackwardFrom(point)
+    @cursor.setBufferPosition(target)
+
   # Add the next sexp to the cursor's selection. Activate if necessary.
   markSexp: ->
     range = @cursor.getMarker().getBufferRange()
@@ -427,6 +439,52 @@ class EmacsCursor
       result or point
     else
       @_locateBackwardFrom(point, /[\W\n]/i)?.end or BOB
+
+  _listForwardFrom: (point) ->
+    eob = @editor.getEofBufferPosition()
+    point = @_locateForwardFrom(point, /[()[\]{}]/i)?.start or eob
+    character = @_nextCharacterFrom(point)
+    if OPENERS.hasOwnProperty(character) or CLOSERS.hasOwnProperty(character)
+      result = null
+      stack = []
+      eof = @editor.getEofBufferPosition()
+      re = /[^()[\]{}\\]+|\\.|[()[\]{}]/g
+      @editor.scanInBufferRange re, [point, eof], (hit) =>
+        if hit.matchText == stack[stack.length - 1]
+          stack.pop()
+          if stack.length == 0
+            result = hit.range.end
+            hit.stop()
+        else if (closer = OPENERS[hit.matchText])
+          stack.push(closer)
+        else if CLOSERS[hit.matchText]
+          if stack.length == 0
+            hit.stop()
+      result or point
+    else
+      eob
+
+  _listBackwardFrom: (point) ->
+    point = @_locateBackwardFrom(point, /[()[\]{}]/i)?.end or BOB
+    character = @_previousCharacterFrom(point)
+    if OPENERS.hasOwnProperty(character) or CLOSERS.hasOwnProperty(character)
+      result = null
+      stack = []
+      re = /[^()[\]{}\\]+|\\.|[()[\]{}]/g
+      @editor.backwardsScanInBufferRange re, [BOB, point], (hit) =>
+        if hit.matchText == stack[stack.length - 1]
+          stack.pop()
+          if stack.length == 0
+            result = hit.range.start
+            hit.stop()
+        else if (opener = CLOSERS[hit.matchText])
+            stack.push(opener)
+        else if OPENERS[hit.matchText]
+          if stack.length == 0
+            hit.stop()
+      result or point
+    else
+      BOB
 
   _locateBackwardFrom: (point, regExp) ->
     result = null

--- a/lib/emacs-editor.coffee
+++ b/lib/emacs-editor.coffee
@@ -67,6 +67,14 @@ class EmacsEditor
     @moveEmacsCursors (emacsCursor) ->
       emacsCursor.skipSexpForward()
 
+  backwardList: ->
+    @moveEmacsCursors (emacsCursor) ->
+      emacsCursor.skipListBackward()
+
+  forwardList: ->
+    @moveEmacsCursors (emacsCursor) ->
+      emacsCursor.skipListForward()
+
   previousLine: ->
     @editor.moveCursors (cursor) ->
       cursor.moveUp()

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
       "atomic-emacs:forward-word",
       "atomic-emacs:backward-sexp",
       "atomic-emacs:forward-sexp",
+      "atomic-emacs:backward-list",
+      "atomic-emacs:forward-list",
       "atomic-emacs:previous-line",
       "atomic-emacs:next-line",
       "atomic-emacs:backward-paragraph",

--- a/spec/atomic-emacs-spec.coffee
+++ b/spec/atomic-emacs-spec.coffee
@@ -142,6 +142,28 @@ describe "AtomicEmacs", ->
       atom.commands.dispatch @editorView, 'atomic-emacs:forward-sexp'
       expect(@testEditor.getState()).toEqual(" aa[0]")
 
+  describe "atomic-emacs:backward-list", ->
+    it "moves all cursors backward one list expression", ->
+      @testEditor.setState("(aa {bb})\naa [0]\n(bb cc)[1]\n")
+      atom.commands.dispatch @editorView, 'atomic-emacs:backward-list'
+      expect(@testEditor.getState()).toEqual("[0](aa {bb})\naa \n[1](bb cc)\n")
+
+    it "merges cursors that coincide", ->
+      @testEditor.setState("{aa}[0] [1]")
+      atom.commands.dispatch @editorView, 'atomic-emacs:backward-list'
+      expect(@testEditor.getState()).toEqual("[0]{aa} ")
+
+  describe "atomic-emacs:forward-list", ->
+    it "moves all cursors forward one list expression", ->
+      @testEditor.setState("[0]a{a}\n[1](bb cc)\n")
+      atom.commands.dispatch @editorView, 'atomic-emacs:forward-list'
+      expect(@testEditor.getState()).toEqual("a{a}[0]\n(bb cc)[1]\n")
+
+    it "merges cursors that coincide", ->
+      @testEditor.setState("[0] [1]aa")
+      atom.commands.dispatch @editorView, 'atomic-emacs:forward-list'
+      expect(@testEditor.getState()).toEqual(" aa[0]")
+
   describe "atomic-emacs:previous-line", ->
     it "moves the cursor up one line", ->
       @testEditor.setState("ab\na[0]b\n")


### PR DESCRIPTION
Lists are a subset of symbolic expressions. These commands move "across ... balanced groups of parentheses. (Other syntactic entities such as words or paired string quotes are ignored.)" (https://www.gnu.org/software/emacs/manual/html_node/elisp/List-Motion.html). In our case, we consider '()', '[]', and '{}' to be symbols that represent parenthetical expressions. 'backward-list' and 'forward-list' are bound to 'ctrl-alt-p' and 'ctrl-alt-n' respectively.