### PR TITLE
Add keymaps for autocomplete navigation on linux

### DIFF
--- a/keymaps/atomic-emacs.cson
+++ b/keymaps/atomic-emacs.cson
@@ -158,6 +158,10 @@
 
 'atom-text-editor.autocomplete-active':
   'ctrl-g': 'autocomplete-plus:cancel'
+  
+'.platform-linux atom-text-editor.autocomplete-active':
+  'ctrl-p': 'core:move-up'
+  'ctrl-n': 'core:move-down'
 
 'atom-text-editor !important, atom-text-editor[mini] !important':
   'ctrl-g': 'editor:consolidate-selections'


### PR DESCRIPTION
On OSX it seems like ctrl-p, ctrl-n work out of the box for navigating the autocomplete menu. On linux I have to resort to using the arrow keys in the absence of this additional keymap.