### PR TITLE
added indentation

### DIFF
--- a/keymaps/atomic-emacs.cson
+++ b/keymaps/atomic-emacs.cson
@@ -85,6 +85,7 @@
   'alt-/': 'autocomplete-plus:activate'
   'alt-q': 'autoflow:reflow-selection'
   'alt-;': 'editor:toggle-line-comments'
+  'ctrl-alt-\\' : 'editor:auto-indent'
 
   # Marking & Selecting
   'ctrl-space': 'atomic-emacs:set-mark'


### PR DESCRIPTION
pretty self explanatory. This was the only default emacs-keybinding that I have noticed to be missing. 