### PR TITLE
keymaps: fix autocomplete up-down navigation

### DIFF
--- a/keymaps/atomic-emacs.cson
+++ b/keymaps/atomic-emacs.cson
@@ -165,6 +165,8 @@
 
 'atom-text-editor.autocomplete-active':
   'ctrl-g': 'autocomplete-plus:cancel'
+  'ctrl-n': 'core:move-down'
+  'ctrl-p': 'core:move-up'
 
 'atom-text-editor !important, atom-text-editor[mini] !important':
   'ctrl-g': 'editor:consolidate-selections'


### PR DESCRIPTION
Hey. I'm just learning the editor, so the patch might be not ideal.
Please let me know if there's a better way to do this.